### PR TITLE
発案者（originator）モデル作成

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -29,7 +29,7 @@ jobs:
       - name: create and migrate database
         run: |
           docker-compose exec -T web rails db:create
-          docker-compose exec -T web rails db:migrate
+          docker-compose exec -T web rails db:migrate RAILS_ENV=test
 
       - name: exec rspec
         run: |

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           docker-compose exec -T web rails assets:precompile
 
-      - name: create database
+      - name: create and migrate database
         run: |
           docker-compose exec -T web rails db:create
           docker-compose exec -T web rails db:migrate

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -29,6 +29,7 @@ jobs:
       - name: create database
         run: |
           docker-compose exec -T web rails db:create
+          docker-compose exec -T web rails db:migrate
 
       - name: exec rspec
         run: |

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,4 +18,3 @@
 //    margin: 0px;
 //    padding: 0px;
 //   }
-  

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,4 @@
 //    margin: 0px;
 //    padding: 0px;
 //   }
+  

--- a/app/models/originator.rb
+++ b/app/models/originator.rb
@@ -1,0 +1,4 @@
+class Originator < ApplicationRecord
+  validates :name, :email, presence: true
+  validates :email, uniqueness: true
+end

--- a/db/migrate/20220504010551_create_originators.rb
+++ b/db/migrate/20220504010551_create_originators.rb
@@ -1,0 +1,11 @@
+class CreateOriginators < ActiveRecord::Migration[6.1]
+  def change
+    create_table :originators do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+
+      t.timestamps
+    end
+    add_index :originators, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2022_05_04_010551) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "originators", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_originators_on_email", unique: true
+  end
+
+end

--- a/spec/factories/originators.rb
+++ b/spec/factories/originators.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :originator do
+    name { "MyString" }
+    email { "MyString" }
+  end
+end

--- a/spec/models/originator_spec.rb
+++ b/spec/models/originator_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Originator, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
- アイデア登録時に発案者モデルとの関連付けが必要なため、先にモデルを作成しました。
- 専用アカウントの機能実装の際にモデル作成も同じブランチで行うと、モデルに変更があった際に修正が大変になるのでモデル作成は別ブランチにしました。