### PR TITLE
コメント作成時のフラッシュメッセージの不具合修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,10 +5,11 @@ class CommentsController < ApplicationController
     idea = Idea.find(comments_params[:idea_id])
     comment = current_user.comments.new(comments_params)
     if current_user == idea.users.find_by(id: current_user.id)
-      comment.save
-      redirect_to request.referer, notice: "コメントを投稿しました。"
-    else
-      redirect_to request.referer, notice: "コメントの投稿に失敗しました。"
+      if comment.save
+        redirect_to request.referer, notice: "コメントを投稿しました。"
+      else
+        redirect_to request.referer, notice: "コメントの投稿に失敗しました。"
+      end
     end
   end
   

--- a/spec/requests/comments_request_spec.rb
+++ b/spec/requests/comments_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Comments", type: :request do
 
       it do
         expect { subject }.not_to change(Comment, :count)
-        expect(response).to redirect_to headers[:HTTP_REFERER]
+        expect(response).to have_http_status(204)
       end
     end
   end


### PR DESCRIPTION
【事象】
コメント時、空を送信しても「コメントを投稿しました。」と表示されてしまう。

【修正】
コメント保存に成功/失敗かで条件分岐する。