### PR TITLE
ideaテーブルに絵文字のカラムを追加

### DIFF
--- a/db/migrate/20220710001441_add_emoji_to_ideas.rb
+++ b/db/migrate/20220710001441_add_emoji_to_ideas.rb
@@ -1,0 +1,5 @@
+class AddEmojiToIdeas < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ideas, :emoji, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_19_062801) do
+ActiveRecord::Schema.define(version: 2022_07_10_001441) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2022_06_19_062801) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "emoji"
     t.index ["user_id"], name: "index_ideas_on_user_id"
   end
 

--- a/spec/factories/ideas.rb
+++ b/spec/factories/ideas.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     outline { "MyText" }
     detail { "MyText" }
     user
+    emoji { "😀" }
   end
 end


### PR DESCRIPTION
コンソールでIdeaモデル経由で絵文字を入れてみました
コンソール上では文字化けが表示されてしまいしたが、文字数は1のようなので絵文字一文字だけ入っている状態かと
```
irb(main):018:0> Idea.where(id: 1).first()
  Idea Load (0.7ms)  SELECT "ideas".* FROM "ideas" WHERE "ideas"."id" = $1 ORDER BY "ideas"."id" ASC LIMIT $2  [["id", 1], ["LIMIT", 1]]
=> #<Idea id: 1, title: "a", outline: "a", detail: "a", user_id: 1, created_at: "2022-05-22 03:42:28.441635000 +0900", updated_at: "2022-07-10 09:23:20.178629000 +0900", emoji: "�😀">4
irb(main):019:0> Idea.where(id: 1).first().emoji.length
  Idea Load (0.6ms)  SELECT "ideas".* FROM "ideas" WHERE "ideas"."id" = $1 ORDER BY "ideas"."id" ASC LIMIT $2  [["id", 1], ["LIMIT", 1]]
=> 1
```