### PR TITLE
絵文字を入力必須にした

### DIFF
--- a/app/javascript/packs/emoji_button.js
+++ b/app/javascript/packs/emoji_button.js
@@ -37,7 +37,6 @@ window.addEventListener("turbolinks:load", function() {
       return false;
     }
   ).group];
-  console.log(initCategory);
 
   // emojipicker生成
   const container = document.querySelector('.pickerContainer');
@@ -52,7 +51,13 @@ window.addEventListener("turbolinks:load", function() {
   });
 
   //選択された絵文字をセットする
+  setEmojiField(initEmoji);
   picker.addEventListener('emoji:select', event => {
-    document.getElementById('emoji_field').value = event.emoji;
+    setEmojiField(event.emoji);
   });
 });
+
+function setEmojiField(emoji) {
+  document.getElementById('emoji_field').value = emoji;
+  document.getElementById('emoji_show').innerHTML = emoji;
+}

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -1,5 +1,5 @@
 class Idea < ApplicationRecord
-  validates :title, :outline, :detail, :user, presence: true
+  validates :title, :outline, :detail, :user, :emoji, presence: true
   belongs_to :user
   has_many :favorites, dependent: :destroy
   has_many :comments, dependent: :destroy

--- a/app/views/ideas/edit.html.erb
+++ b/app/views/ideas/edit.html.erb
@@ -6,6 +6,7 @@
       <div class="form-group col-md-8 mb-3">
         <label class="form-label h4">アイキャッチ絵文字</label>
         <%= form.hidden_field :'emoji', :id => "emoji_field" , :value => @idea.emoji %>
+        <div id="emoji_show" class="h1"></div>
         <div class="pickerContainer"></div>
       </div>
     </div>

--- a/app/views/ideas/register.html.erb
+++ b/app/views/ideas/register.html.erb
@@ -4,8 +4,9 @@
   <%= form_with model: @idea, url: "/ideas/register", method: :post, role: "form" do |form|%>
     <div class="row">
       <div class="form-group col-md-8 mb-3">
-        <label class="form-label h4">アイキャッチ絵文字</label>
-        <%= form.hidden_field :'emoji', :id => "emoji_field" , :value => "" %>
+        <label for="emoji_field" class="form-label h4">アイキャッチ絵文字</label>
+        <%= form.hidden_field :'emoji', :id => "emoji_field" %>
+        <div id="emoji_show" class="h1"></div>
         <div class="pickerContainer"></div>
       </div>
     </div>

--- a/db/migrate/20220717074313_change_emoji_add_not_null_on_ideas.rb
+++ b/db/migrate/20220717074313_change_emoji_add_not_null_on_ideas.rb
@@ -1,0 +1,5 @@
+class ChangeEmojiAddNotNullOnIdeas < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :ideas, :emoji, :false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_10_001441) do
+ActiveRecord::Schema.define(version: 2022_07_17_074313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/idea_spec.rb
+++ b/spec/models/idea_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Idea, type: :model do
   describe 'validation' do
     subject { idea } 
     let(:user) { build(:user) }
-    let(:idea) { build(:idea, title: title, outline: outline, detail: detail, user: user) }
+    let(:idea) { build(:idea, title: title, outline: outline, detail: detail, user: user, emoji: emoji) }
 
     context "normal" do
       let(:idea) {build(:idea)}

--- a/spec/requests/ideas_controllers_spec.rb
+++ b/spec/requests/ideas_controllers_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Ideas", type: :request do
 
   describe "POST /ideas/register" do
     subject { post '/ideas/register', params: params}
-    let(:idea) { build(:idea, title: title, outline: outline, detail: detail, user: user) }
+    let(:idea) { build(:idea, title: title, outline: outline, detail: detail, user: user, emoji: emoji) }
     let(:params) { { idea: attributes_for(:idea)} }
     context "user is authenticated" do
       let(:idea) {build(:idea)}
@@ -54,7 +54,7 @@ RSpec.describe "Ideas", type: :request do
 
   describe "GET ideas/edit/:id" do
     subject { get "/ideas/edit/#{idea.id}", params: params}
-    let(:idea) { create(:idea, title: title, outline: outline, detail: detail, user: user) }
+    let(:idea) { create(:idea, title: title, outline: outline, detail: detail, user: user, emoji: emoji) }
     let(:params) { { idea: {id: idea.id} } }
     context "user is authenticated" do
       let(:idea) {create(:idea, user: user)}
@@ -83,7 +83,7 @@ RSpec.describe "Ideas", type: :request do
 
   describe "PUT /ideas/:id" do
     subject { put "/ideas/#{idea.id}", params: params}
-    let(:idea) { create(:idea, title: title, outline: outline, detail: detail, user: user) }
+    let(:idea) { create(:idea, title: title, outline: outline, detail: detail, user: user, emoji: emoji) }
     let(:params) { { idea: {id: idea.id, title: "updated_title", outline: "updated_outline", detail: "updated_detail"} } }
     context "user is authenticated" do
       let(:idea) { create(:idea, user: user) }
@@ -120,7 +120,7 @@ RSpec.describe "Ideas", type: :request do
 
   describe "PUT /ideas/:id/favorite" do
     subject { put "/ideas/#{idea.id}/favorite", params: params}
-    let(:idea) { create(:idea, title: title, outline: outline, detail: detail, user: user) }
+    let(:idea) { create(:idea, title: title, outline: outline, detail: detail, user: user, emoji: emoji) }
     let(:params) { { idea: {id: idea.id} } }
     context "user is authenticated" do
       let(:idea) { create(:idea, user: user) }


### PR DESCRIPTION
テーブル定義変更
モデルクラスのバリデーション追加
デフォルトでタネの絵文字をを選択
テストを修正

あとついでに選択中の絵文字を表示するようにしました

![image](https://user-images.githubusercontent.com/37746586/179390812-479f085d-f70b-433f-89e5-854b5684f165.png)
